### PR TITLE
Enable profile file localization and improve env variable detection 

### DIFF
--- a/yarn-deployment/dbt_commands.py
+++ b/yarn-deployment/dbt_commands.py
@@ -21,7 +21,7 @@ import sys
 import uuid
 
 from datetime import datetime
-from dotenv import load_dotenv
+from dotenv import load_dotenv,find_dotenv
 
 logging.basicConfig(
     level=logging.DEBUG, format="%(asctime)s - %(levelname)s: %(message)s"
@@ -35,7 +35,7 @@ sys_args = []
 def load_fetch_environment_variables():
     # load the environment variables from .env file
     logging.info("Loading environment variables.")
-    load_dotenv()
+    load_dotenv(find_dotenv())
     logging.info("Done Loading environment variables.")
 
     # fetch the environment variables


### PR DESCRIPTION
**Before behaviour:**

profiles.yml had to be copied to /tmp folder before in all hosts in the cluster to get dbt-docs to work.

**After behaviour:**
profiles.yml is only available in gateway machine. It is copied to persistent storage (hdfs here) and then when the yarn container is brought up it downloads it from hdfs to local host.

**Testing:**
Tested by running dbt docs with parameters through passed through .env and making sure its up

`[root@tsenapati-1 yarn-changes]#  yarn logs -applicationId application_1667572610634_0058 | grep '7777'
WARNING: YARN_OPTS has been replaced by HADOOP_OPTS. Using value of YARN_OPTS.
22/11/07 13:01:31 INFO client.RMProxy: Connecting to ResourceManager at tsenapati-2.tsenapati.root.hwx.site/172.27.34.146:8032
        launchCommand: mkdir -p /tmp/dbt-2022-11-07-13-00-49 && hdfs dfs -copyToLocal /tmp/dbt_profiles.tar.gz /tmp/dbt-2022-11-07-13-00-49 && cd /tmp/dbt-2022-11-07-13-00-49  && tar -xzvf dbt_profiles.tar.gz && python3 -m venv /tmp/dbt-yarn && source /tmp/dbt-yarn/bin/activate && pip install dbt-hive dbt-impala && git clone $GIT_PROJECT_URL && cd $DBT_PROJECT_PATH && dbt docs generate --profiles-dir=/tmp/dbt-2022-11-07-13-00-49 ; echo 'DBT docs hosted on port 7777 on host: ' $(hostname) >&2 && python3 -m http.server 7777 --directory target 
DBT docs hosted on port 7777 on host:  tsenapati-3.tsenapati.root.hwx.site`

 
<img width="1728" alt="image" src="https://user-images.githubusercontent.com/2308360/200317151-f5841588-2b89-40a5-8bd2-5f0fb911332b.png">
