### PR TITLE
Add precheck conditions for env variables,and fix formatting

### DIFF
--- a/yarn-deployment/yarn_dbt.py
+++ b/yarn-deployment/yarn_dbt.py
@@ -107,7 +107,7 @@ def check_environment_variables(ENV_VARIABLES):
     ENV_VARIABLES.setdefault("DBT_DOCS_PORT", "7777")
     ENV_VARIABLES.setdefault("YARN_CONTAINER_MEMORY", "2048")
     ENV_VARIABLES.setdefault("YARN_TIMEOUT", "1800000")
-    ENV_VARIABLES.setdefault("APPLICATION_TAGS", "test-dbt")
+    ENV_VARIABLES.setdefault("APPLICATION_TAGS", "yarn-dbt")
     
 
 # Perform kerberos authorization in gateway machine


### PR DESCRIPTION


- Fixed issue with dependencies package in yarn.env 
- check for necessary keys in yarn.env . Populate optional keys with default values
- Remove verbose logging. Can be fine-tuned by changing env variable LOGLEVEL

Testing:

Clean run to make sure dbt commands succeed.

Removed few necessary keys/made typos and check user received error message

```
(test-yarn) [root@tsenapati-dh-1 dbt-hive-example]# yarn_dbt debug
['/root/cloudera-dbt-deployment/yarn-deployment/test-yarn/bin/yarn_dbt', 'debug']
2022-11-17 02:23:26,980 - CRITICAL: Missing keys in yarn.env: ['DEPENDENCIES_PACKAGE_PATH_HDFS', 'DBT_SERVICE_USER', 'DBT_PROJECT_NAME']
(test-yarn) [root@tsenapati-dh-1 dbt-hive-example]# 
```

Removed optional keys and making sure run succeeds with default values